### PR TITLE
beryllium: Unset VINTF target level

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device" target-level="3">
+<manifest version="1.0" type="device">
     <hal format="hidl">
         <name>android.hardware.gnss</name>
         <transport>hwbinder</transport>


### PR DESCRIPTION
Now that all mi845 targets are set to the same target level,
this is going to be commonized.

Change-Id: I082840481e8dfef4cbcfa247213848aaa9abaa8c
Signed-off-by: Akhil Narang <me@akhilnarang.dev>